### PR TITLE
Fixes false response from PS check in non-PS world

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.com.mineauz</groupId>
     <artifactId>BuildTools</artifactId>
-    <version>1.17.1-SNAPSHOT</version>
+    <version>1.19.2-SNAPSHOT</version>
     <name>BuildTools</name>
     <properties>
         <build.number/>
         <plugin.version>${project.version}-${build.number}</plugin.version>
         <mainClass>au.com.mineauz.buildtools.BTPlugin</mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spigot.api.version>1.17</spigot.api.version>
-        <spigot.version>1.17.1-R0.1-SNAPSHOT</spigot.version>
+        <spigot.api.version>1.19</spigot.api.version>
+        <spigot.version>1.19.2-R0.1-SNAPSHOT</spigot.version>
     </properties>
     <licenses>
         <license>
@@ -89,8 +89,8 @@
         </repository>
         <!-- PlotSquared -->
         <repository>
-            <id>IntellectualSites</id>
-            <url>https://mvn.intellectualsites.com/content/groups/public/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
@@ -105,8 +105,8 @@
         <!-- GriefPrevention -->
         <dependency>
             <groupId>com.github.TechFortress</groupId>
-            <artifactId>griefprevention</artifactId>
-            <version>16.17.1</version>
+            <artifactId>GriefPrevention</artifactId>
+            <version>16.18</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -115,14 +115,14 @@
         <dependency>
             <groupId>com.plotsquared</groupId>
             <artifactId>PlotSquared-Core</artifactId>
-            <version>6.0.8-SNAPSHOT</version>
+            <version>6.10.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- PlotSquared Bukkit API -->
         <dependency>
             <groupId>com.plotsquared</groupId>
             <artifactId>PlotSquared-Bukkit</artifactId>
-            <version>6.0.8-SNAPSHOT</version>
+            <version>6.10.2</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.6-SNAPSHOT</version>
+            <version>7.0.8-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -192,7 +192,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <release>16</release>
                 </configuration>

--- a/src/main/java/au/com/mineauz/buildtools/protection/PSPlugin.java
+++ b/src/main/java/au/com/mineauz/buildtools/protection/PSPlugin.java
@@ -18,6 +18,10 @@ public class PSPlugin implements ProtectionPlugin {
 				location.getBlockZ()
 		);
 
+		// Checks if world is not a Plot world, then ignore
+		if (l.getPlotArea() == null) return true;
+
+		// Checks if player is in a plot and added
 		if (l.getPlotAbs() != null) {
 			return l.getPlotAbs().isAdded(player.getUniqueId());
 		} else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,8 +10,8 @@ maxVolume:
 # Permission for added groups: buildtools.hightlimit.<groupName>
 heightLimits:
   default:
-  - 0
-  - 255
+  - -63
+  - 320
 
 # Block materials that cannot be used in BuildTools.
 # More groups can be added to disallow specific blocks per group.
@@ -50,8 +50,9 @@ disabledBlocks:
   - CAULDRON
   - CHAIN
   - CHEST
+  - CHEST_MINECART
   - COMMAND
-  - COMMAND_MINECART
+  - COMMAND_BLOCK_MINECART
   - CRIMSON_ROOTS
   - CROPS
   - CYAN_CANDLE
@@ -67,12 +68,14 @@ disabledBlocks:
   - DROPPER
   - EMPTY_MAP
   - ENCHANTMENT_TABLE
+  - END_CRYSTAL
   - ENDER_PORTAL
   - ENDER_PORTAL_FRAME
   - END_ROD
   - EXPLOSIVE_MINECART
   - FIRE
   - FLOWER_POT
+  - FURNACE_MINECART
   - GLOW_BERRIES
   - GLOW_LICHEN
   - GRAY_CANDLE
@@ -96,12 +99,15 @@ disabledBlocks:
   - LIGHTNING_ROD
   - LIME_CANDLE
   - MAGENTA_CANDLE
+  - MANGROVE_PROPAGULe
   - MEDIUM_AMETHYST_BUD
   - MINECART
   - MOB_SPAWNER
   - NETHER_SPROUTS
+  - OCHRE_FROGLIGHT
   - ORANGE_CANDLE
   - PAINTING
+  - PEARLESCENT_FROGLIGHT
   - PINK_CANDLE
   - PISTON_BASE
   - PISTON_EXTENSION
@@ -127,6 +133,9 @@ disabledBlocks:
   - RED_MUSHROOM
   - RED_ROSE
   - SAPLING
+  - SCULK_SENSOR
+  - SCULK_SHRIEKER
+  - SEA_PICKLE
   - SIGN
   - SIGN_POST
   - SKULL
@@ -141,11 +150,13 @@ disabledBlocks:
   - STORAGE_MINECART
   - TALL_GRASS
   - TNT
+  - TNT_MINECART
   - TORCH
   - TRAPPED_CHEST
   - TRAP_DOOR
   - TRIPWIRE_HOOK
   - TWISTING_VINES
+  - VERDANT_FROGLIGHT
   - VINE
   - WALL_BANNER
   - WALL_SIGN


### PR DESCRIPTION
This fixes a "false" response when checking PS support. Previously worked fine for a PS world, but not a GP world.
Adds additional blocks to the diabledBlocks list.
Updates to 1.19.2