### PR TITLE
Adds commons-lang3 dependency to fix menu validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -194,7 +199,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <release>16</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/au/com/mineauz/buildtools/menu/Menu.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/Menu.java
@@ -4,7 +4,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;

--- a/src/main/java/au/com/mineauz/buildtools/menu/MenuItem.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/MenuItem.java
@@ -3,7 +3,7 @@ package au.com.mineauz.buildtools.menu;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/au/com/mineauz/buildtools/menu/MenuItemString.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/MenuItemString.java
@@ -3,7 +3,7 @@ package au.com.mineauz.buildtools.menu;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 

--- a/src/main/java/au/com/mineauz/buildtools/menu/MenuPage.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/MenuPage.java
@@ -1,6 +1,6 @@
 package au.com.mineauz.buildtools.menu;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/au/com/mineauz/buildtools/menu/MenuPageInventory.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/MenuPageInventory.java
@@ -2,7 +2,7 @@ package au.com.mineauz.buildtools.menu;
 
 import java.util.Arrays;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/au/com/mineauz/buildtools/menu/MenuPageNormal.java
+++ b/src/main/java/au/com/mineauz/buildtools/menu/MenuPageNormal.java
@@ -1,7 +1,7 @@
 package au.com.mineauz.buildtools.menu;
 
 import com.google.common.collect.Iterators;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;


### PR DESCRIPTION
This adds commons-lang3 dependency to fix menu validation. Previous build would occasionally build fine, then sometimes not.