### PR TITLE
Switch to Paper 1.21.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ BuildTools is based around simple block breaking and placing as opposed to a sel
 commands.
 </p>
 <p>
-Compiling currently requires the latest Bukkit, WorldGuard, GriefPrevention and PlotMe. The plugins 
+Compiling currently requires the latest Paper API, WorldGuard, GriefPrevention and PlotMe. The plugins
 are required for stopping players from building in protected areas using this plugin.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.com.mineauz</groupId>
     <artifactId>BuildTools</artifactId>
-    <version>1.19.2-SNAPSHOT</version>
+    <version>1.21.7-SNAPSHOT</version>
     <name>BuildTools</name>
     <properties>
         <build.number/>
         <plugin.version>${project.version}-${build.number}</plugin.version>
         <mainClass>au.com.mineauz.buildtools.BTPlugin</mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spigot.api.version>1.19</spigot.api.version>
-        <spigot.version>1.19.2-R0.1-SNAPSHOT</spigot.version>
+        <paper.api.version>1.21</paper.api.version>
+        <paper.version>1.21.7-R0.1-SNAPSHOT</paper.version>
     </properties>
     <licenses>
         <license>
@@ -96,9 +96,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>${spigot.version}</version>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/au/com/mineauz/buildtools/BTPlayer.java
+++ b/src/main/java/au/com/mineauz/buildtools/BTPlayer.java
@@ -266,16 +266,13 @@ public class BTPlayer {
 			}
 
 			@Override
-			public String getValue() {
-				String set = null;
-				if(tSettings.length > 0)
-					set = "";
-				for(String s : tSettings)
-					set += s + " ";
-				return set;
-			}
-		};
-	}
+                        public String getValue() {
+                                if (tSettings.length == 0)
+                                        return null;
+                                return String.join(" ", tSettings);
+                        }
+                };
+        }
 	
 	public void setTSettings(String[] settings){
 		tSettings = settings;
@@ -297,16 +294,13 @@ public class BTPlayer {
 			}
 
 			@Override
-			public String getValue() {
-				String set = null;
-				if(pSettings.length > 0)
-					set = "";
-				for(String s : pSettings)
-					set += s + " ";
-				return set;
-			}
-		};
-	}
+                        public String getValue() {
+                                if (pSettings.length == 0)
+                                        return null;
+                                return String.join(" ", pSettings);
+                        }
+                };
+        }
 	
 	public void setPSettings(String[] settings){
 		pSettings = settings;

--- a/src/main/java/au/com/mineauz/buildtools/BTPlugin.java
+++ b/src/main/java/au/com/mineauz/buildtools/BTPlugin.java
@@ -102,7 +102,7 @@ public class BTPlugin extends JavaPlugin{
 		
 		HandlerList.unregisterAll(this);
 		
-		getLogger().info(" successfully disabled!");
+                getLogger().info("Successfully disabled!");
 	}
 	
 	public PlayerData getPlayerData(){

--- a/src/main/java/au/com/mineauz/buildtools/Events.java
+++ b/src/main/java/au/com/mineauz/buildtools/Events.java
@@ -65,7 +65,7 @@ public class Events implements Listener{
 			
 			if(!pdata.getPlayerBlockLimits(pl).contains(event.getBlockPlaced().getType()) ||
 					pl.hasPermission("buildtools.bypassdisabledblocks")){
-				Integer[] hl = pdata.getPlayerHightLimits(pl);
+                                Integer[] hl = pdata.getPlayerHeightLimits(pl);
 				if((event.getBlock().getLocation().getBlockY() <= hl[1] && 
 						event.getBlock().getLocation().getBlockY() >= hl[0]) ||
 						pl.hasPermission("buildtools.bypassheightlimit")){
@@ -149,7 +149,7 @@ public class Events implements Listener{
 			
 			if(!pdata.getPlayerBlockLimits(pl).contains(Material.AIR) || 
 					pl.hasPermission("buildtools.bypassdisabledblocks")){
-				Integer[] hl = pdata.getPlayerHightLimits(pl);
+                                Integer[] hl = pdata.getPlayerHeightLimits(pl);
 				if((event.getBlock().getLocation().getBlockY() <= hl[1] && 
 						event.getBlock().getLocation().getBlockY() >= hl[0]) ||
 						pl.hasPermission("buildtools.bypassheightlimit")){

--- a/src/main/java/au/com/mineauz/buildtools/Generator.java
+++ b/src/main/java/au/com/mineauz/buildtools/Generator.java
@@ -121,7 +121,7 @@ public class Generator implements Runnable{
 					}
 					
 					if(copy.isReplacing() || state.getBlock().getState().getType() == Material.AIR){
-						Integer[] lim = BTPlugin.plugin.getPlayerData().getPlayerHightLimits(player);
+                Integer[] lim = BTPlugin.plugin.getPlayerData().getPlayerHeightLimits(player);
 						if(state.getLocation().getBlockY() >= lim[0] && state.getLocation().getY() <= lim[1]){
 							BTUtils.placeBlock(player, state.getLocation(), state.getBlockData(), BuildMode.OVERWRITE, undo);
 						}

--- a/src/main/java/au/com/mineauz/buildtools/PlayerData.java
+++ b/src/main/java/au/com/mineauz/buildtools/PlayerData.java
@@ -137,14 +137,14 @@ public class PlayerData {
 		plugin.saveConfig();
 	}
 	
-	public Integer[] getPlayerHightLimits(BTPlayer player){
-		for(String l : heightLimits.keySet()){
-			if(player.hasPermission("buildtools.heightlimit." + l)){
-				return heightLimits.get(l);
-			}
-		}
-		return getHeightLimits("default");
-	}
+        public Integer[] getPlayerHeightLimits(BTPlayer player){
+                for(String l : heightLimits.keySet()){
+                        if(player.hasPermission("buildtools.heightlimit." + l)){
+                                return heightLimits.get(l);
+                        }
+                }
+                return getHeightLimits("default");
+        }
 	
 	public void addVolumeLimit(String name, int limit) throws DuplicateLimitException{
 		name = name.toLowerCase();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,7 +7,7 @@ maxVolume:
 # Height limits for players to use BuildTools, Min 0, Max 255.
 # More groups can be added to allow certain players to build higher/lower.
 # First item on list is minimum height, second is maximum.
-# Permission for added groups: buildtools.hightlimit.<groupName>
+# Permission for added groups: buildtools.heightlimit.<groupName>
 heightLimits:
   default:
   - -63

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ${project.name}
 main: ${mainClass}
 version: ${plugin.version}
-api-version: ${spigot.api.version}
+api-version: ${paper.api.version}
 author: _Razz_
 softdepend: [GriefPrevention, WorldGuard, PlotMe]
 
@@ -10,7 +10,7 @@ commands:
     description: The BuildTools base command.
     usage: Invalid command. Type "/buildtools help" for help
     permission: buildtools.command
-    permisison-message: You don't have permission to use this command <permission>
+    permission-message: You don't have permission to use this command <permission>
     aliases: [bt, btm]
 
 permissions:


### PR DESCRIPTION
## Summary
- update dependency to Paper API 1.21.7
- fix typos and rename a height limit helper method
- improve settings callback handling
- tweak disable log message
- correct config comment and plugin.yml formatting

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873081618a4832c8790fa4ef109c5d2